### PR TITLE
Add refresh button to question table

### DIFF
--- a/frontend/src/components/questions/QuestionDialog.js
+++ b/frontend/src/components/questions/QuestionDialog.js
@@ -4,8 +4,17 @@ import EditButton from './EditQuestionButton';
 import CloseIcon from '@mui/icons-material/Close';
 import ReactMarkdown from 'react-markdown';
 import DeleteQuestion from "./DeleteQuestionDialog";
+import useAuth from "../../hooks/useAuth";
 
 const QuestionDialog = ({ open, question, onClose }) => {
+    const { priviledge } = useAuth();
+
+    const dialogActionsComponent = (
+        <DialogActions sx={{ justifyContent: 'flex-end', padding: '16px',  backgroundColor:'#D9D9D9' }}>
+            <EditButton question={question}/>
+            <DeleteQuestion question={question}/>
+        </DialogActions>);
+
     if (!question) return null;  // If no problem is selected, return null
 
     return (
@@ -87,10 +96,7 @@ const QuestionDialog = ({ open, question, onClose }) => {
 
             </DialogContent>
 
-            <DialogActions sx={{ justifyContent: 'flex-end', padding: '16px',  backgroundColor:'#D9D9D9' }}>
-                <EditButton question={question}/>
-                <DeleteQuestion question={question}/>
-            </DialogActions>
+            {priviledge ? dialogActionsComponent : null}
         </Dialog>
     );
 };

--- a/frontend/src/components/questions/QuestionTable.js
+++ b/frontend/src/components/questions/QuestionTable.js
@@ -15,7 +15,7 @@ const columns = [
   { id: 'status', label: 'Status', minWidth: 100 }
 ];
 
-export default function QuestionTable() {
+export default function QuestionTable({ mountTrigger }) {
   const [page, setPage] = React.useState(0);
   const [rowsPerPage, setRowsPerPage] = React.useState(10);
 
@@ -49,7 +49,7 @@ export default function QuestionTable() {
         }
       };
       fetchQuestions(); // Trigger the fetch
-  }, []);
+  }, [mountTrigger]);
 
   const handleQuestionClick = (question) => {
     setSelectedQuestion(question); 

--- a/frontend/src/components/questions/refreshTableButton.js
+++ b/frontend/src/components/questions/refreshTableButton.js
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import { useState } from 'react';
+import { Button } from '@mui/material';
+
+const refreshIcon = (
+    <svg 
+        id="Layer_1"
+        width='40'
+        height='40'
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 119.4 122.88">
+        <title>Reload Table</title>
+        <path d="M83.91,26.34a43.78,43.78,0,0,0-22.68-7,42,42,0,0,0-24.42,7,49.94,49.94,0,0,0-7.46,6.09,42.07,42.07,0,0,0-5.47,54.1A49,49,0,0,0,30,94a41.83,41.83,0,0,0,18.6,10.9,42.77,42.77,0,0,0,21.77.13,47.18,47.18,0,0,0,19.2-9.62,38,38,0,0,0,11.14-16,36.8,36.8,0,0,0,1.64-6.18,38.36,38.36,0,0,0,.61-6.69,8.24,8.24,0,1,1,16.47,0,55.24,55.24,0,0,1-.8,9.53A54.77,54.77,0,0,1,100.26,108a63.62,63.62,0,0,1-25.92,13.1,59.09,59.09,0,0,1-30.1-.25,58.45,58.45,0,0,1-26-15.17,65.94,65.94,0,0,1-8.1-9.86,58.56,58.56,0,0,1,7.54-75,65.68,65.68,0,0,1,9.92-8.09A58.38,58.38,0,0,1,61.55,2.88,60.51,60.51,0,0,1,94.05,13.3l-.47-4.11A8.25,8.25,0,1,1,110,7.32l2.64,22.77h0a8.24,8.24,0,0,1-6.73,9L82.53,43.31a8.23,8.23,0,1,1-2.9-16.21l4.28-.76Z" fill='white'/>
+    </svg>
+);
+
+
+const RefreshTableButton = ({ trigger }) => {
+    return (<>
+        <Button
+            variant="contained"
+            onClick={trigger} // Opens the dialog on button click
+            sx={{
+                width: '54px',
+                height: '54px',
+                flexShrink: 0,
+                backgroundColor: '#443CBD',
+                '&:hover': {
+                    backgroundColor: '#915edc',
+                },
+                marginTop: '10px',
+            }}
+        >
+            {refreshIcon}
+        </Button>
+    </>);
+}
+
+export default RefreshTableButton;

--- a/frontend/src/hooks/useAuth.js
+++ b/frontend/src/hooks/useAuth.js
@@ -7,6 +7,7 @@ const useAuth = () => {
   const navigate = useNavigate();
   const [cookies, removeCookie] = useCookies([]);
   const [username, setUsername] = useState("");
+  const [priviledge, setPriviledge] = useState("");
 
   useEffect(() => {
     const verifyCookie = async () => {
@@ -26,8 +27,8 @@ const useAuth = () => {
         );
         if (response.status === 200) {
           const { data } = response.data;
-          const user = data.username;
-          setUsername(user);
+          setUsername(data.username);
+          setPriviledge(data.isAdmin);
         } else {
           removeCookie("token");
           navigate("/login");
@@ -41,7 +42,7 @@ const useAuth = () => {
     verifyCookie();
   }, [cookies, navigate, removeCookie]);
 
-  return { username, cookies, removeCookie };
+  return { username, priviledge, cookies, removeCookie };
 };
 
 export default useAuth;

--- a/frontend/src/pages/Questions.jsx
+++ b/frontend/src/pages/Questions.jsx
@@ -1,20 +1,16 @@
+import { useState } from "react";
+
 import GeneralNavbar from "../components/navbar/GeneralNavbar";
-import QuestionTable from '../components/questions/QuestionTable'
-import AddQuestionButton from '../components/questions/AddQuestionButtons'
+import QuestionTable from '../components/questions/QuestionTable';
+import AddQuestionButton from '../components/questions/AddQuestionButtons';
+import RefreshTableButton from '../components/questions/refreshTableButton';
+
 import '../styles/questions.css';
-import { useNavigate } from "react-router-dom";
-import useAuth from "../hooks/useAuth";
 import 'react-toastify/dist/ReactToastify.css';
 
 const Questions = () => {
-    
-  const navigate = useNavigate();
-  const { username, removeCookie } = useAuth();
-
-  const Logout = () => {
-    removeCookie("token");
-    navigate("/login");
-  };
+    const [refresh, setRefresh] = useState(true);
+    const toggle = () => setRefresh(!refresh);
 
     return (
         <div>
@@ -23,10 +19,13 @@ const Questions = () => {
                 <h1>Questions</h1>
                 <p className="description">View all the questions stored in database.</p>
                 <div className="question-table-container">
-                    <div className="admin-button">
-                        <AddQuestionButton/>
+                    <div className="table-buttons">
+                        <RefreshTableButton trigger={toggle}/>
+                        <div className="admin-button">
+                            <AddQuestionButton />
+                        </div>
                     </div>
-                    <QuestionTable />
+                    <QuestionTable mountTrigger={refresh} />
                 </div>
             </div>
         </div>

--- a/frontend/src/pages/Questions.jsx
+++ b/frontend/src/pages/Questions.jsx
@@ -4,11 +4,13 @@ import GeneralNavbar from "../components/navbar/GeneralNavbar";
 import QuestionTable from '../components/questions/QuestionTable';
 import AddQuestionButton from '../components/questions/AddQuestionButtons';
 import RefreshTableButton from '../components/questions/refreshTableButton';
+import useAuth from "../hooks/useAuth";
 
 import '../styles/questions.css';
 import 'react-toastify/dist/ReactToastify.css';
 
 const Questions = () => {
+    const { priviledge } = useAuth();
     const [refresh, setRefresh] = useState(true);
     const toggle = () => setRefresh(!refresh);
 
@@ -22,7 +24,7 @@ const Questions = () => {
                     <div className="table-buttons">
                         <RefreshTableButton trigger={toggle}/>
                         <div className="admin-button">
-                            <AddQuestionButton />
+                            {priviledge ? <AddQuestionButton /> : null}
                         </div>
                     </div>
                     <QuestionTable mountTrigger={refresh} />

--- a/frontend/src/styles/questions.css
+++ b/frontend/src/styles/questions.css
@@ -31,8 +31,13 @@ h1 {
     margin: auto;
 }
 
-.admin-button {
+.table-buttons {
+    display: flex;
     position: absolute;
     top: -90px; /* Adjust as needed */
     right: 0;
+}
+
+.admin-button {
+    margin-left: 8px;
 }


### PR DESCRIPTION
### New refresh button
Situated to the left of the "Add Question" button. Just a button to re-mount the question table (rather than having to reload the entire page).

![image](https://github.com/user-attachments/assets/956309e3-2b07-4b6e-9aa0-c365c5040f9d)

### Hide/Show Question buttons
The add/edit/delete question button now only displays if the user is an admin. 

Normal user Pov:
![image](https://github.com/user-attachments/assets/432d01f5-f96b-4307-af70-a70c5eb6159e)

Admin PoV:
![image](https://github.com/user-attachments/assets/20348910-4bfe-4cff-ab6c-396e9a4cd5e9)

