### PR TITLE
Fix containerization environments

### DIFF
--- a/backend/question-backend/.gitignore
+++ b/backend/question-backend/.gitignore
@@ -1,5 +1,5 @@
 /node_modules
 
 .DS_Store
-.env
+.env*
 google-key.json

--- a/backend/question-backend/README.md
+++ b/backend/question-backend/README.md
@@ -4,9 +4,9 @@
 
 2. Run the command: `npm install`. This will install all the necessary dependencies.
 
-3. Run the command `npm start` to start the Question Service in production mode, or use `npm run dev` for development mode, which includes features like automatic server restart when you make code changes.
+3. Run the command `NODE_ENV=development npm start` to start the Question Service in production mode, or use `NODE_ENV=development npm run dev` for development mode, which includes features like automatic server restart when you make code changes.
 
-4. Using applications like Postman, you can interact with the User Service on port 4000. If you wish to change this, please update the `.env` file (there is a sample file under `.envsample`).
+4. Using applications like Postman, you can interact with the User Service on port 4000. If you wish to change this, please update the `.env.local` and `.env` files (there is a sample file under `.envsample`).
 
 ## Running Question Service (Containerized)
 

--- a/backend/question-backend/index.js
+++ b/backend/question-backend/index.js
@@ -4,9 +4,14 @@ import cors from "cors";
 import dotenv from "dotenv";
 import questionRoutes from "./routes/question-route.js";
 
-dotenv.config();
+// Load environment variables conditionally
+if (process.env.NODE_ENV === 'development') {
+  dotenv.config({ path: '.env.local' });
+} else {
+  dotenv.config();
+}
 
-const { MONGO_URL, QUESTION_PORT } = process.env;
+const { MONGO_URL, QUESTION_PORT, USER_AUTH_URL } = process.env;
 
 const app = express();
 
@@ -18,6 +23,7 @@ mongoose
 
 app.listen(QUESTION_PORT, () => {
   console.log(`Question server is listening on port ${QUESTION_PORT}`);
+  console.log(`User Auth URL: ${USER_AUTH_URL}`);
 });
 
 // Middleware

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,5 @@
-# Specify the version of the Docker Compose.
 version: "3.9"
 
-# Define the services and applications that make up your application.
 services:
   frontend-service:
     build: ./frontend
@@ -10,6 +8,9 @@ services:
     volumes:
       - ./frontend:/app
       - /app/node_modules
+    environment:
+      - NODE_ENV=production
+      - USER_AUTH_URL=http://user-service:3001/auth/verify-token
     networks:
       - common-network
 
@@ -20,6 +21,9 @@ services:
     volumes:
       - ./backend/question-backend:/app
       - /app/node_modules
+    environment:
+      - NODE_ENV=production
+      - USER_AUTH_URL=http://user-service:3001/auth/verify-token
     networks:
       - common-network
 
@@ -33,9 +37,10 @@ services:
       - ./backend/user-backend/googleKey.json:/app/googleKey.json
       - /app/node_modules
     environment:
-      NODE_ENV: production
+      - NODE_ENV=production
+      - USER_AUTH_URL=http://user-service:3001/auth/verify-token
     env_file:
-      ./backend/user-backend/.env
+      - ./backend/user-backend/.env
     networks:
       - common-network
 

--- a/frontend/src/components/questions/QuestionTable.js
+++ b/frontend/src/components/questions/QuestionTable.js
@@ -40,7 +40,7 @@ export default function QuestionTable({ mountTrigger }) {
   useEffect(() => {
       const fetchQuestions = async () => {
         try {
-          const response = await questionService.getAllQuestions();
+          const response = await questionService.getAllQuestions(cookies);
           setQuestions(response);
         } catch (error) {
             setErrorMessage(error.message); // Set error message


### PR DESCRIPTION
When running the application on Docker containers, there is an issue with the linking between question-service and user-service in terms of the `USER_AUTH_URL`. Since the containers are different in these two services, they refer to different `localhost`, hence we had to change it to `user-service` instead.

But this causes an issue when trying to run it locally, since there isn't a `user-service`, so I split the environment variables such that they are loaded conditionally based on the environment – `development` (for local) / `production` (for docker containers).

Things to note:
- Create a new file `.env.local` in the `question-backend` folder with `USER_AUTH_URL="http://localhost:3001/auth/verify-token"`
- Remove `USER_AUTH_URL` from `.env` file
- When running locally, run `NODE_ENV=development npm start` instead of `npm start`