### PR TITLE
Add history language support and submit button function

### DIFF
--- a/backend/history-backend/src/controller.js
+++ b/backend/history-backend/src/controller.js
@@ -42,13 +42,13 @@ export async function getSomeHistory(req, res) {
 }
 
 export async function addHistory(req, res) {
-  const { roomId, question, user, partner, status, datetime, solution } = req.body;
+  const { roomId, question, user, partner, status, datetime, solution, language } = req.body;
 
   if (!(roomId && question && user && partner && status && datetime))
     return res.status(400).json({ message: "Missing one or more of the required fields" });
 
   try {
-    let newHistory = { roomId, question, user, partner, status, datetime, solution };
+    let newHistory = { roomId, question, user, partner, status, datetime, solution, language };
 
     const existingHistory = await _getHistoryByRoomIdAndUser(roomId, user);
     if (existingHistory)

--- a/backend/history-backend/src/model.js
+++ b/backend/history-backend/src/model.js
@@ -30,7 +30,12 @@ const HistoryModelSchema = new Schema({
     type: String,
     required: true,
     default: '',
-  }
+  },
+  language: {
+    type: String,
+    required: true,
+    default: 'python',
+  },
 });
 
 export default mongoose.model("history", HistoryModelSchema);

--- a/frontend/src/components/collaboration/SubmitPopup.jsx
+++ b/frontend/src/components/collaboration/SubmitPopup.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import '../../styles/CollabPopup.css';
+
+const SubmitPopup = ({ confirmQuit, cancelQuit }) => {
+    return (
+        <div className="overlay">
+            <dialog open className="dialog-popup">
+                <div className="popup-content">
+                    <h3>Submit code?</h3>
+                    <p>The session will end once you submit your code.</p>
+                    <button className="confirm-button" onClick={confirmQuit}>Confirm</button>
+                    <button className="cancel-button" onClick={cancelQuit}>Cancel</button>
+                </div>
+            </dialog>
+        </div>
+    );
+};
+
+export default SubmitPopup;

--- a/frontend/src/components/history/CodeDialog.js
+++ b/frontend/src/components/history/CodeDialog.js
@@ -3,7 +3,7 @@ import CloseIcon from '@mui/icons-material/Close';
 import ReactMarkdown from 'react-markdown';
 import Monaco from "@monaco-editor/react";
 
-const CodeDialog = ({ open, onClose, question, solution }) => {
+const CodeDialog = ({ open, onClose, question, solution, language }) => {
   if (!question) return null;
 
   return (
@@ -100,7 +100,7 @@ const CodeDialog = ({ open, onClose, question, solution }) => {
         <Monaco
           height="100%"
           width="50%"
-          language="python"
+          language={language || 'python'} // default to python
           theme="vs-dark"
           value={solution}
           options={{

--- a/frontend/src/components/history/HistoryTable.jsx
+++ b/frontend/src/components/history/HistoryTable.jsx
@@ -71,9 +71,9 @@ export default function HistoryTable() {
     setOpen(true);
   };
 
-  const handleSolutionClick = (question, solution) => {
+  const handleSolutionClick = (question, solution, language) => {
     setSelectedQuestion(question);
-    setSelectedSolution(solution);
+    setSelectedSolution({solution, language});
     setOpen(true);
   }
 
@@ -141,7 +141,7 @@ export default function HistoryTable() {
 
                     <TableCell>
                       <Button
-                        onClick={() => handleSolutionClick(row.question, row.solution)}
+                        onClick={() => handleSolutionClick(row.question, row.solution, row.language)}
                         sx={{
                           color: 
                             row.status.toLowerCase() === 'attempted' ? '#FFB800' :
@@ -194,7 +194,8 @@ export default function HistoryTable() {
           open={open}
           onClose={handleCloseDialog} 
           question={selectedQuestion} 
-          solution={selectedSolution}
+          solution={selectedSolution.solution}
+          language={selectedSolution.language}
         />
       )}
     </Paper>

--- a/frontend/src/pages/Collab.jsx
+++ b/frontend/src/pages/Collab.jsx
@@ -10,6 +10,7 @@ import io from 'socket.io-client';
 import CollabNavBar from "../components/navbar/CollabNavbar";
 import QuestionContainer from "../components/collaboration/QuestionContainer";
 import QuitConfirmationPopup from "../components/collaboration/QuitConfirmationPopup";
+import SubmitPopup from "../components/collaboration/SubmitPopup";
 import PartnerQuitPopup from "../components/collaboration/PartnerQuitPopup";
 import TimeUpPopup from "../components/collaboration/TimeUpPopup";
 import historyService from "../services/history-service";
@@ -34,6 +35,7 @@ const Collab = () => {
     const [countdown, setCountdown] = useState(20); // set to 1 min default timer
     const [timeOver, setTimeOver] = useState(false);
 
+    const [showSubmitPopup, setShowSubmitPopup] = useState(false);
     const [showQuitPopup, setShowQuitPopup] = useState(false);
     const [showPartnerQuitPopup, setShowPartnerQuitPopup] = useState(false);
 
@@ -151,11 +153,6 @@ const Collab = () => {
     const { question, language, matchedUser, roomId, datetime } = location.state;
     const partnerUsername = matchedUser.user1 === username ? matchedUser.user2 : matchedUser.user1;
 
-    const handleSubmit = () => {
-        console.log("Submit code");
-        attemptStatus.current = "submitted";
-    };
-
     const handleQuit = () => setShowQuitPopup(true);
 
     const handleQuitConfirm = () => {
@@ -175,6 +172,16 @@ const Collab = () => {
     };
 
     const handleQuitCancel = () => setShowQuitPopup(false);
+
+    const handleSubmit = () => setShowSubmitPopup(true);
+
+    const handleSubmitConfirm = () => {
+        console.log("Submit code");
+        attemptStatus.current = "submitted";
+        handleQuitConfirm(); // invoke quit function
+    };
+
+    const handleSubmitCancel = () => setShowSubmitPopup(false);
 
     const handleContinueSession = () => {
         socketRef.current.emit("continue-session", roomId);
@@ -222,6 +229,12 @@ const Collab = () => {
                     />
                 </div>
                 {/* Conditionally render popups */}
+                {showSubmitPopup && (
+                    <SubmitPopup
+                        confirmQuit={handleSubmitConfirm}
+                        cancelQuit={handleSubmitCancel}
+                    />
+                )}
                 {showQuitPopup && (
                     <QuitConfirmationPopup 
                         confirmQuit={handleQuitConfirm} 


### PR DESCRIPTION
Quick fix for handling non-python language sessions, and now a user clicking submit will show a confirmation popup, pressing confirm will invoke quit function (with attempt status `submitted` instead) and redirect user back to home page.
Might refactor and improve later next week or smth.